### PR TITLE
Don't set sling:message when a label is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dictionaries with .json files are no longer showed in dictionary
   list: [#8](https://github.com/orbinson/aem-dictionary-translator/pull/5)
+- Labels with no translation for a specific language no longer have a
+sling:message so the value won't be empty but will have a fallback
+from another language or the key itself: [#12](https://github.com/orbinson/aem-dictionary-translator/pull/12)
 
 ### Added
 

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServlet.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 @Component(service = Servlet.class)
@@ -70,11 +71,13 @@ public class CreateLabelServlet extends SlingAllMethodsServlet {
 
         if (resource != null) {
             String path = resource.getPath();
-            resourceResolver.create(resource, JcrUtil.createValidName(key), Map.of(
-                    "jcr:primaryType", "sling:MessageEntry",
-                    "sling:key", key,
-                    "sling:message", message
-            ));
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("jcr:primaryType", "sling:MessageEntry");
+            properties.put("sling:key", key);
+            if (!message.isBlank()){
+                properties.put("sling:message", message);
+            }
+            resourceResolver.create(resource, JcrUtil.createValidName(key), properties);
             LOG.trace("Create label with key '{}' and message '{}' on path '{}'", key, message, path);
             resourceResolver.commit();
         }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServlet.java
@@ -22,6 +22,11 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_KEY;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGE;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGEENTRY;
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
+
 @Component(service = Servlet.class)
 @SlingServletResourceTypes(
         resourceSuperType = "granite/ui/components/coral/foundation/form",
@@ -72,10 +77,10 @@ public class CreateLabelServlet extends SlingAllMethodsServlet {
         if (resource != null) {
             String path = resource.getPath();
             Map<String, Object> properties = new HashMap<>();
-            properties.put("jcr:primaryType", "sling:MessageEntry");
-            properties.put("sling:key", key);
+            properties.put(JCR_PRIMARYTYPE, SLING_MESSAGEENTRY);
+            properties.put(SLING_KEY, key);
             if (!message.isBlank()){
-                properties.put("sling:message", message);
+                properties.put(SLING_MESSAGE, message);
             }
             resourceResolver.create(resource, JcrUtil.createValidName(key), properties);
             LOG.trace("Create label with key '{}' and message '{}' on path '{}'", key, message, path);

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServlet.java
@@ -25,6 +25,9 @@ import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGE;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGEENTRY;
+
 @Component(service = Servlet.class)
 @SlingServletResourceTypes(
         resourceSuperType = "granite/ui/components/coral/foundation/form",
@@ -89,9 +92,9 @@ public class UpdateLabelServlet extends SlingAllMethodsServlet {
                     ValueMap valueMap = labelResource.adaptTo(ModifiableValueMap.class);
                     if (valueMap != null) {
                         if (message.isBlank()) {
-                            valueMap.remove("sling:message");
+                            valueMap.remove(SLING_MESSAGE);
                         } else {
-                            valueMap.put("sling:message", message);
+                            valueMap.put(SLING_MESSAGE, message);
                             LOG.trace("Updated label with name '{}' and message '{}' on path '{}'", name, message, labelResource.getPath());
                         }
                     }
@@ -106,7 +109,7 @@ public class UpdateLabelServlet extends SlingAllMethodsServlet {
     public Resource getLabelResource(ResourceResolver resourceResolver, Resource languageResource, String name) throws RepositoryException {
         if (languageResource.getChild(name) == null) {
             Session session = resourceResolver.adaptTo(Session.class);
-            JcrUtil.createPath(languageResource.getPath() + "/" + name, "sling:MessageEntry", session);
+            JcrUtil.createPath(languageResource.getPath() + "/" + name, SLING_MESSAGEENTRY, session);
             session.save();
         }
         return languageResource.getChild(name);

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServlet.java
@@ -88,8 +88,12 @@ public class UpdateLabelServlet extends SlingAllMethodsServlet {
                 if (labelResource != null) {
                     ValueMap valueMap = labelResource.adaptTo(ModifiableValueMap.class);
                     if (valueMap != null) {
-                        valueMap.put("sling:message", message);
-                        LOG.trace("Updated label with name '{}' and message '{}' on path '{}'", name, message, labelResource.getPath());
+                        if (message.isBlank()) {
+                            valueMap.remove("sling:message");
+                        } else {
+                            valueMap.put("sling:message", message);
+                            LOG.trace("Updated label with name '{}' and message '{}' on path '{}'", name, message, labelResource.getPath());
+                        }
                     }
                 }
                 resourceResolver.commit();
@@ -99,7 +103,7 @@ public class UpdateLabelServlet extends SlingAllMethodsServlet {
         }
     }
 
-    private Resource getLabelResource(ResourceResolver resourceResolver, Resource languageResource, String name) throws RepositoryException {
+    public Resource getLabelResource(ResourceResolver resourceResolver, Resource languageResource, String name) throws RepositoryException {
         if (languageResource.getChild(name) == null) {
             Session session = resourceResolver.adaptTo(Session.class);
             JcrUtil.createPath(languageResource.getPath() + "/" + name, "sling:MessageEntry", session);

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServletTest.java
@@ -18,7 +18,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_KEY;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGE;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGEENTRY;
 import static junit.framework.Assert.assertNull;
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -85,9 +89,9 @@ class CreateLabelServletTest {
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/en/greeting");
         ValueMap properties = resource.getValueMap();
         assertNotNull(resource);
-        assertEquals("sling:MessageEntry", properties.get("jcr:primaryType"));
-        assertEquals("greeting", properties.get("sling:key"));
-        assertEquals("Hello", properties.get("sling:message"));
+        assertEquals(SLING_MESSAGEENTRY, properties.get(JCR_PRIMARYTYPE));
+        assertEquals("greeting", properties.get(SLING_KEY));
+        assertEquals("Hello", properties.get(SLING_MESSAGE));
     }
 
     @Test
@@ -110,9 +114,8 @@ class CreateLabelServletTest {
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/fr/greeting");
         ValueMap properties = resource.getValueMap();
         assertNotNull(resource);
-        assertEquals("sling:MessageEntry", properties.get("jcr:primaryType"));
-        assertEquals("greeting", properties.get("sling:key"));
-//        assertEquals("Hello", properties.get("sling:message"));
-        assertNull(properties.get("sling:message"));
+        assertEquals(SLING_MESSAGEENTRY, properties.get(JCR_PRIMARYTYPE));
+        assertEquals("greeting", properties.get(SLING_KEY));
+        assertNull(properties.get(SLING_MESSAGE));
     }
 }

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLabelServletTest.java
@@ -18,6 +18,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 
+import static junit.framework.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -87,5 +88,31 @@ class CreateLabelServletTest {
         assertEquals("sling:MessageEntry", properties.get("jcr:primaryType"));
         assertEquals("greeting", properties.get("sling:key"));
         assertEquals("Hello", properties.get("sling:message"));
+    }
+
+    @Test
+    void doPostWithEmptyMessage() throws ServletException, IOException {
+        context.create().resource("/content/dictionaries/i18n/en", Map.of("jcr:language", "en"));
+        context.create().resource("/content/dictionaries/i18n/fr", Map.of("jcr:language", "fr"));
+
+        context.request().setMethod("POST");
+        context.request().setParameterMap(Map.of(
+                "dictionary", "/content/dictionaries/i18n",
+                "key", "greeting",
+                "en", "Hello",
+                "fr", ""
+        ));
+
+        servlet.service(context.request(), context.response());
+
+        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+
+        Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/fr/greeting");
+        ValueMap properties = resource.getValueMap();
+        assertNotNull(resource);
+        assertEquals("sling:MessageEntry", properties.get("jcr:primaryType"));
+        assertEquals("greeting", properties.get("sling:key"));
+//        assertEquals("Hello", properties.get("sling:message"));
+        assertNull(properties.get("sling:message"));
     }
 }

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateLabelServletTest.java
@@ -19,6 +19,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_KEY;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGE;
+import static be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants.SLING_MESSAGEENTRY;
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -72,12 +76,12 @@ class UpdateLabelServletTest {
         context.create().resource("/content/dictionaries/i18n/en", Map.of("jcr:language", "en"));
         context.create().resource("/content/dictionaries/i18n/en/appel", Map.of(
                 "dictionary", "/content/dictionaries/i18n", "key", "appel",
-                "en", "apple", "sling:MessageEntry", "jcr:primaryType")
+                "en", "apple", SLING_MESSAGEENTRY, JCR_PRIMARYTYPE)
         );
         context.create().resource("/content/dictionaries/i18n/fr", Map.of("jcr:language", "fr"));
         context.create().resource("/content/dictionaries/i18n/en/appel", Map.of(
                 "dictionary", "/content/dictionaries/i18n", "key", "appel",
-                "fr", "pomme", "sling:MessageEntry", "jcr:primaryType")
+                "fr", "pomme", SLING_MESSAGEENTRY, JCR_PRIMARYTYPE)
         );
 
         context.request().setMethod("POST");
@@ -95,8 +99,8 @@ class UpdateLabelServletTest {
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/en/appel");
         ValueMap properties = resource.getValueMap();
         assertNotNull(resource);
-        assertEquals("sling:MessageEntry", properties.get("jcr:primaryType"));
-        assertEquals("appel", properties.get("sling:key"));
-        assertEquals("Hello", properties.get("sling:message"));
+        assertEquals(SLING_MESSAGEENTRY, properties.get(JCR_PRIMARYTYPE));
+        assertEquals("appel", properties.get(SLING_KEY));
+        assertEquals("Hello", properties.get(SLING_MESSAGE));
     }
 }


### PR DESCRIPTION
empty translations no longer leave empty sling:message, the sling:message property gets deleted.

resolves #9 