### PR TITLE
Do no longer reference (potentially outdated) versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To deploy the AEM Dictionary Translator as an embedded package you need to updat
    <dependency>
      <groupId>be.orbinson.aem</groupId>
      <artifactId>aem-dictionary-translator.all</artifactId>
-     <version>1.1.2</version>
+     <version><replace with last release version></version>
      <type>zip</type>
    </dependency>
    ```


### PR DESCRIPTION
Instead just use a placeholder so there is no need to update the README after every release.