### PR TITLE
Sort languages returned by DictionaryService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add option to publish to preview [#43](https://github.com/orbinson/aem-dictionary-translator/issues/43)
 - Added /conf as editable root for dictionaries [#46](https://github.com/orbinson/aem-dictionary-translator/issues/46)
 - Update maven dependencies [#51](https://github.com/orbinson/aem-dictionary-translator/pull/51)
+- Sort dictionary languages alphanumeric [#52] (https://github.com/orbinson/aem-dictionary-translator/pull/52)
 
 ### Fixed
 

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImpl.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImpl.java
@@ -73,7 +73,7 @@ public class DictionaryServiceImpl implements DictionaryService {
     }
 
     public @NotNull Map<String, String> getLanguagesForPath(ResourceResolver resourceResolver, String dictionaryPath) {
-        Map<String, String> result = new HashMap<>();
+        Map<String, String> result = new TreeMap<>();
         Resource resource = resourceResolver.getResource(dictionaryPath);
 
         if (resource != null && translationConfig != null) {
@@ -138,7 +138,7 @@ public class DictionaryServiceImpl implements DictionaryService {
 
 
     public List<String> getLanguages(Resource dictionaryResource) {
-        List<String> result = new ArrayList<>();
+        Set<String> result = new TreeSet<>();
 
         dictionaryResource.listChildren().forEachRemaining(child -> {
             ValueMap properties = child.getValueMap();
@@ -148,7 +148,7 @@ public class DictionaryServiceImpl implements DictionaryService {
             }
         });
 
-        return result;
+        return new ArrayList<>(result);
     }
 
     @Override

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImplTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImplTest.java
@@ -49,9 +49,9 @@ class DictionaryImplTest {
     @Test
     void testGetLanguages() {
         final List<String> expectedLanguages = new ArrayList<>();
+        expectedLanguages.add("de");
         expectedLanguages.add("en");
         expectedLanguages.add("fr");
-        expectedLanguages.add("de");
 
         final Resource testResource = context.currentResource("/content/dictionaries/languages");
         if (testResource != null) {
@@ -70,7 +70,7 @@ class DictionaryImplTest {
 
     @Test
     void testGetLanguagesString() {
-        final String expectedLanguages = "en, fr, de";
+        final String expectedLanguages = "de, en, fr";
 
         final Resource testResource = context.currentResource("/content/dictionaries/languages");
         if (testResource != null) {

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImplTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImplTest.java
@@ -68,8 +68,8 @@ class DictionaryServiceImplTest {
 
         List<String> languages = dictionaryService.getLanguages(context.currentResource("/content/dictionaries/site/i18"));
 
-        assertEquals("fr", languages.get(0));
-        assertEquals("en", languages.get(1));
+        assertEquals("en", languages.get(0));
+        assertEquals("fr", languages.get(1));
     }
 
 


### PR DESCRIPTION
Sort languages alphanumeric to group regional languages like en_US and en_GB together.