### PR TITLE
Remove shortcut "d" for delete language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+-   Remove shortcut `d` for "Delete Language" as it conflicts with `Cmd + Opt + I` on Mac OS Chrome (Open Developer Tools)
 -   Fix publication error when too many keys are selected [#45](https://github.com/orbinson/aem-dictionary-translator/issues/45)
 -   Fix publication timeout when for large dictionaries [#44](https://github.com/orbinson/aem-dictionary-translator/issues/44)
 

--- a/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/content/dictionaries/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/content/dictionaries/.content.xml
@@ -82,7 +82,6 @@
                         sling:resourceType="granite/ui/components/coral/foundation/collection/action"
                         activeSelectionCount="single"
                         action="foundation.dialog"
-                        command="d"
                         icon="deleteOutline"
                         variant="actionBar"
                         text="Delete Language">


### PR DESCRIPTION
Somehow this shortcut conflicts with internal Chrome shortcuts like `Cmd + Option + I` (to open Developer Tools) on Mac OS

This closes #53 

Provide a general summary of your changes in the title above if needed

## Checklist before requesting a review

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [x] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
