### PR TITLE
Evaluate Session.hasCapability(...) to check if dictionary is editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Dictionaries in /apps and /libs should not be marked as editable in AEMaaCS [#132](https://github.com/orbinson/aem-dictionary-translator/issues/132)
+
 ## [1.3.3] - 2025-03-07
 
 ### Fixed

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImpl.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/DictionaryServiceImpl.java
@@ -49,8 +49,11 @@ public class DictionaryServiceImpl implements DictionaryService {
                         accessControlManager.privilegeFromName(Privilege.JCR_REMOVE_NODE),
                         accessControlManager.privilegeFromName("crx:replicate")
                 };
-                return accessControlManager.hasPrivileges(path, privileges);
+                // https://jackrabbit.apache.org/oak/docs/nodestore/compositens.html#checking-for-read-only-access
+                boolean isPathWritable= session.hasCapability("addNode", path, new Object[] { "nt:folder" });
+                return isPathWritable && accessControlManager.hasPrivileges(path, privileges);
             } catch (RepositoryException e) {
+                LOG.debug("Could not check if dictionary is editable, therefore assume it is not!", e);
                 return false;
             }
         }


### PR DESCRIPTION
This considers limitations of Composite NodeStores used in AEMaaCS

This closes #132


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [x] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
