### PR TITLE
Support read-only view of JSON-file based dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Dictionaries in /apps and /libs should not be marked as editable in AEMaaCS [#132](https://github.com/orbinson/aem-dictionary-translator/issues/132)
+- Support JSON file based dictionaries in read-only mode [#26](https://github.com/orbinson/aem-dictionary-translator/issues/26)
 
 ## [1.3.3] - 2025-03-07
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example `org.apache.sling.i18n.impl.JcrResourceBundleProvider` OSGi config
 
 ## Limitations
 
-1. Only [`sling:Message` or `sling:MessageEntry` based dictionaries](https://sling.apache.org/documentation/bundles/internationalization-support-i18n.html#slingmessageentry-jcrprimarytype-or-slingmessage-jcrmixintypes-based) are supported but not ones in [JSON format](https://github.com/orbinson/aem-dictionary-translator/issues/26).
+1. Only [`sling:Message` or `sling:MessageEntry` based dictionaries](https://sling.apache.org/documentation/bundles/internationalization-support-i18n.html#slingmessageentry-jcrprimarytype-or-slingmessage-jcrmixintypes-based) are supported in edit mode, the ones in [JSON format](https://github.com/orbinson/aem-dictionary-translator/issues/26) are exposed in read-only mode.
 2. Due to the [search order of dictionaries](https://sling.apache.org/documentation/bundles/internationalization-support-i18n.html#resourcebundle-hierarchies) it is not possible to overwrite entries from dictionaries within `/libs` (shipped with AEM) with different translations leveraging a dictionary placed below `/content`.
 
 ## Development

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,11 +82,6 @@ Import-Package: javax.annotation;version=0.0.0,*
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>jackrabbit-jcr-commons</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,7 @@ Import-Package: javax.annotation;version=0.0.0,*
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -84,6 +84,10 @@ Import-Package: javax.annotation;version=0.0.0,*
         </dependency>
 
         <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/Dictionary.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/Dictionary.java
@@ -1,9 +1,14 @@
 package be.orbinson.aem.dictionarytranslator.models;
 
-import org.apache.sling.api.resource.Resource;
-
 import java.util.List;
 
+import org.apache.sling.api.resource.Resource;
+import org.osgi.annotation.versioning.ProviderType;
+
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
+
+@ProviderType
 public interface Dictionary {
     Resource getResource();
 
@@ -13,9 +18,11 @@ public interface Dictionary {
 
     List<String> getLanguages();
 
-    List<String> getKeys();
+    List<String> getKeys() throws DictionaryException;
 
     boolean isEditable();
 
-    int getKeyCount();
+    int getKeyCount() throws DictionaryException;
+    
+    DictionaryService.DictionaryType getType();
 }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImpl.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImpl.java
@@ -1,7 +1,10 @@
 package be.orbinson.aem.dictionarytranslator.models.impl;
 
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
 import be.orbinson.aem.dictionarytranslator.models.Dictionary;
 import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService.DictionaryType;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
@@ -48,12 +51,18 @@ public class DictionaryImpl implements Dictionary {
     }
 
     @Override
-    public int getKeyCount() {
+    public int getKeyCount() throws DictionaryException {
         return getKeys().size();
     }
 
     @Override
-    public List<String> getKeys() {
+    public List<String> getKeys() throws DictionaryException {
         return dictionaryService.getKeys(resource);
     }
+
+    @Override
+    public DictionaryType getType() {
+        return dictionaryService.getType(resource);
+    }
+
 }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/package-info.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/models/package-info.java
@@ -1,4 +1,4 @@
-@Version("2.0.0")
+@Version("3.0.0")
 package be.orbinson.aem.dictionarytranslator.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
@@ -41,6 +41,14 @@ public interface DictionaryService {
 
     List<String> getKeys(Resource dictionaryResource) throws DictionaryException;
 
+    /**
+     * Returns the message entry for the given language and key.
+     * @param dictionaryResource
+     * @param language
+     * @param key
+     * @return {@code true} if the message entry exists, {@code false} otherwise
+     * @throws DictionaryException if either language or key does not exist below the given dictionary resource
+     */
     boolean keyExists(Resource dictionaryResource, String language, String key) throws DictionaryException;
 
     /**
@@ -49,8 +57,8 @@ public interface DictionaryService {
      * @param language
      * @param key
      * @param message
-     * @throws PersistenceException
-     * @throws DictionaryException 
+     * @throws PersistenceException in case creating a new resource failed
+     * @throws DictionaryException in case the language doees not exist below the given dictionary resource
      */
     void createOrUpdateMessageEntry(Resource dictionaryResource, String language, String key, String message) throws PersistenceException, DictionaryException;
 
@@ -60,12 +68,19 @@ public interface DictionaryService {
      * @param dictionaryResource
      * @param language
      * @param key
-     * @throws PersistenceException
-     * @throws ReplicationException
-     * @throws DictionaryException 
+     * @throws PersistenceException in case deleting the resource failed
+     * @throws ReplicationException in case deactivation failed
+     * @throws DictionaryException if either language or key does not exist below the given dictionary resource
      */
     void deleteMessageEntry(Resource dictionaryResource, String language, String key)  throws PersistenceException, ReplicationException, DictionaryException;
 
+    /**
+     * Returns all message entries for the given language below the given dictionary resource.
+     * @param dictionaryResource
+     * @param language
+     * @return all message entries for the given language. The key of the map is the key of the message entry and the value is a {@link Message} object containing the actual text and other metadata.
+     * @throws DictionaryException if the dictionary for the given language does not exist
+     */
     Map<String, Message> getMessages(Resource dictionaryResource, String language) throws DictionaryException;
 
     /** 

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
@@ -1,43 +1,143 @@
 package be.orbinson.aem.dictionarytranslator.services;
 
-import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
-import com.day.cq.replication.ReplicationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.annotation.versioning.ProviderType;
 
-import javax.jcr.RepositoryException;
-import java.util.List;
+import com.day.cq.replication.ReplicationException;
 
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
+
+/**
+ * Low-level service interface for reading and creating/updating/deleting dictionaries in AEM.
+ * <p>
+ * A high-level read-only API is provided by the {@link be.orbinson.aem.dictionarytranslator.models.Dictionary} model and by the {@link be.orbinson.aem.dictionarytranslator.services.impl.CombiningMessageEntryResourceProvider}.
+ *
+ */
+@ProviderType
 public interface DictionaryService {
 
-    boolean isEditableDictionary(Resource resource);
+    boolean isEditableDictionary(Resource dictionaryResource);
 
     List<Resource> getDictionaries(ResourceResolver resourceResolver);
 
     void createDictionary(Resource parent, String name, String[] languages, String basename) throws PersistenceException;
 
-    void deleteDictionary(ResourceResolver resourceResolver, String dictionaryPath) throws DictionaryException;
+    void deleteDictionary(ResourceResolver resourceResolver, String dictionaryPath) throws DictionaryException, ReplicationException, PersistenceException;
 
     List<String> getLanguages(Resource dictionaryResource);
 
-    void deleteLanguage(ResourceResolver resourceResolver, Resource dictionaryResource, String language) throws DictionaryException;
+    void deleteLanguage(Resource dictionaryResource, String language) throws DictionaryException, ReplicationException, PersistenceException;
 
     void addLanguage(Resource dictionaryResource, String language, String basename) throws PersistenceException;
 
-    Resource getLanguageResource(Resource dictionaryResource, String language);
-
     String getBasename(Resource dictionaryResource);
 
-    List<String> getKeys(Resource dictionaryResource);
+    List<String> getKeys(Resource dictionaryResource) throws DictionaryException;
 
-    boolean keyExists(Resource dictionaryResource, String language, String key);
+    boolean keyExists(Resource dictionaryResource, String language, String key) throws DictionaryException;
 
-    Resource getMessageEntryResource(Resource languageResource, String key);
+    /**
+     * Either creates a new message entry or updates an existing one. The changes are not persisted until the resource resolver is committed.
+     * @param dictionaryResource
+     * @param language
+     * @param key
+     * @param message
+     * @throws PersistenceException
+     * @throws DictionaryException 
+     */
+    void createOrUpdateMessageEntry(Resource dictionaryResource, String language, String key, String message) throws PersistenceException, DictionaryException;
 
-    void createMessageEntry(ResourceResolver resourceResolver, Resource dictionaryResource, String language, String key, String message) throws PersistenceException;
+    /**
+     * Deletes the message entry for the given language and key. The changes are not persisted until the resource resolver is committed.
+     * However the message entry is immediately scheduled for deactivation.
+     * @param dictionaryResource
+     * @param language
+     * @param key
+     * @throws PersistenceException
+     * @throws ReplicationException
+     * @throws DictionaryException 
+     */
+    void deleteMessageEntry(Resource dictionaryResource, String language, String key)  throws PersistenceException, ReplicationException, DictionaryException;
 
-    void updateMessageEntry(ResourceResolver resourceResolver, Resource dictionaryResource, String language, String key, String message) throws PersistenceException, RepositoryException;
+    Map<String, Message> getMessages(Resource dictionaryResource, String language) throws DictionaryException;
 
-    void deleteMessageEntry(ResourceResolver resourceResolver, Resource combiningMessageEntryResource) throws PersistenceException, ReplicationException;
+    /** 
+     * Encapsulating a message entry (for one language).
+     * Exposes both the actual text as well as the resource path of the message entry.
+     * The latter is only available if the message is based on a single resource (and not based on a JSON file).
+     */
+    public final class Message {
+        private final String text;
+        private final String resourcePath;
+
+        public Message(String message, String resourcePath) {
+            this.text = message;
+            this.resourcePath = resourcePath;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public Optional<String> getResourcePath() {
+            return Optional.ofNullable(resourcePath);
+        }
+
+        @Override
+        public String toString() {
+            return "Message [text=" + text + ", resourcePath=" + resourcePath + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(text, resourcePath);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Message other = (Message) obj;
+            return Objects.equals(text, other.text) && Objects.equals(resourcePath, other.resourcePath);
+        }
+    }
+
+    enum DictionaryType {
+        SLING_MESSAGE_ENTRY,
+        JSON_FILE,
+        /** the languages below this dictionary have different types, only applicable on dictionary level, not on language level */
+        MIXED
+    }
+
+    /**
+     * Returns the type of the dictionary for the given language.
+     * @param dictionaryResource
+     * @param language
+     * @return the type of the dictionary for the given language
+     * @throws DictionaryException if the dictionary for the given language does not exist
+     */
+    DictionaryType getType(Resource dictionaryResource, String language) throws DictionaryException;
+
+    /**
+     * Returns the type of the dictionary (actually the derived type from the type of all languages).
+     * <p>
+     * This method will return {@link DictionaryType#MIXED} if the dictionary contains languages of different types and 
+     * {@link DictionaryType#SLING_MESSAGE_ENTRY} if the dictionary doesn't contain any languages yet.
+     *
+     * @param dictionaryResource the dictionary resource
+     * @return the derived type of the dictionary
+     */
+    DictionaryType getType(Resource dictionaryResource);
+
 }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
@@ -69,8 +69,8 @@ public interface DictionaryService {
     Map<String, Message> getMessages(Resource dictionaryResource, String language) throws DictionaryException;
 
     /** 
-     * Encapsulating a message entry (for one language).
-     * Exposes both the actual text as well as the resource path of the message entry.
+     * Encapsulating a single message entry (for one language).
+     * Exposes both the actual text as well as the resource path of the source message entry.
      * The latter is only available if the message is based on a single resource (and not based on a JSON file).
      */
     public final class Message {
@@ -114,10 +114,21 @@ public interface DictionaryService {
     }
 
     enum DictionaryType {
-        SLING_MESSAGE_ENTRY,
-        JSON_FILE,
+        SLING_MESSAGE_ENTRY("sling:MessageEntry"),
+        JSON_FILE("JSON file"),
         /** the languages below this dictionary have different types, only applicable on dictionary level, not on language level */
-        MIXED
+        MIXED("Mixed");
+
+        private final String label;
+
+        DictionaryType(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
     }
 
     /**

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
@@ -80,15 +80,10 @@ public class CombiningMessageEntryResourceProvider extends ResourceProvider<Obje
                 }
                 messagePerLanguage.put(language, message);
             }
-           return createResource(parent, resourceResolver, path, dictionaryService.isEditableDictionary(dictionaryResource), messagePerLanguage);
+           return new ValueMapResource(resourceResolver, path, RESOURCE_TYPE, new ValueMapDecorator(createResourceProperties(path, dictionaryService.isEditableDictionary(dictionaryResource), messagePerLanguage)));
         } else {
             throw new ResourceNotFoundException(path, "Unable to get underlying dictionary resource for path '" + dictionaryPath + "'");
         }
-    }
-
-    static @NotNull Resource createResource(@Nullable Resource parent, @NotNull ResourceResolver resourceResolver, 
-            @NotNull String path, boolean isEditable, @NotNull Map<String, Message> messagePerLanguage) {
-        return new ValueMapResource(resourceResolver, path, RESOURCE_TYPE, new ValueMapDecorator(createResourceProperties(path, isEditable, messagePerLanguage)));
     }
 
     private static String extractKeyFromPath(@NotNull String path) {

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
@@ -1,10 +1,16 @@
 package be.orbinson.aem.dictionarytranslator.services.impl;
 
-import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
-import be.orbinson.aem.dictionarytranslator.utils.DictionaryConstants;
-import com.adobe.granite.ui.components.ds.ValueMapResource;
-import com.day.text.Text;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.jackrabbit.util.Text;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceNotFoundException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.spi.resource.provider.ResolveContext;
@@ -15,8 +21,21 @@ import org.jetbrains.annotations.Nullable;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import java.util.*;
+import com.adobe.granite.ui.components.ds.ValueMapResource;
 
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService.Message;
+
+/**
+ * Resource provider exposing all translations for one dictionary entry.
+ * It expects the path to be of the form:
+ * {@code /mnt/dictionary/<dictionaryPath>/<key>}
+ * <p>
+ * The key is unescaped with {@link Text#unescapeIllegalJcrChars(String)} to also allow "/" in it.
+ * This resource provider is used to combine message entries from different languages into a single resource.
+ * It is used in the AEM UI to display the combined message entries for a given key.
+ */
 @Component(
         service = ResourceProvider.class,
         property = {
@@ -37,28 +56,6 @@ public class CombiningMessageEntryResourceProvider extends ResourceProvider<Obje
     @Reference
     private DictionaryService dictionaryService;
 
-    private Map<String, Object> getValuesAndMessageEntryPaths(Resource dictionaryResource, String key, List<String> languages) {
-        Map<String, Object> properties = new HashMap<>();
-        List<String> messageEntryPaths = new ArrayList<>();
-
-        for (String language : languages) {
-            Resource languageResource = dictionaryService.getLanguageResource(dictionaryResource, language);
-            if (languageResource != null) {
-                Resource messageEntryResource = dictionaryService.getMessageEntryResource(languageResource, key);
-                if (messageEntryResource != null) {
-                    properties.put(language, messageEntryResource.getValueMap().get(DictionaryConstants.SLING_MESSAGE, ""));
-                    messageEntryPaths.add(messageEntryResource.getPath());
-                } else {
-                    properties.put(language, "");
-                }
-            }
-        }
-
-        properties.put(MESSAGE_ENTRY_PATHS, messageEntryPaths);
-
-        return properties;
-    }
-
     @Override
     public @Nullable Resource getResource(@NotNull ResolveContext<Object> ctx, @NotNull String path, @NotNull ResourceContext resourceContext, @Nullable Resource parent) {
         ResourceResolver resourceResolver = ctx.getResourceResolver();
@@ -67,45 +64,63 @@ public class CombiningMessageEntryResourceProvider extends ResourceProvider<Obje
             return null;
         }
 
-        String key = Text.getName(path);
-        String dictionaryPath = Text.getRelativeParent(path, 1).replaceFirst(ROOT, "");
+        String key = extractKeyFromPath(path);
+        String dictionaryPath = getDictionaryPath(path);
         Resource dictionaryResource = resourceResolver.getResource(dictionaryPath);
 
-        if (dictionaryResource != null && isMessageEntry(dictionaryResource, key)) {
-            Map<String, Object> properties = new HashMap<>();
-            properties.put(KEY, key);
-            properties.put("path", path);
-            properties.put("editable", dictionaryService.isEditableDictionary(dictionaryResource));
-            properties.put(DICTIONARY_PATH, dictionaryPath);
+        if (dictionaryResource != null) {
+            @NotNull Map<String, Message> messagePerLanguage = new HashMap<>();
             List<String> languages = dictionaryService.getLanguages(dictionaryResource);
-            properties.put(LANGUAGES, languages);
-            properties.putAll(getValuesAndMessageEntryPaths(dictionaryResource, key, languages));
-            return new ValueMapResource(resourceResolver, path, RESOURCE_TYPE, new ValueMapDecorator(properties));
+            for (String language : languages) {
+                Message message;
+                try {
+                    message = dictionaryService.getMessages(dictionaryResource, language).get(key);
+                } catch (DictionaryException e) {
+                    throw new ResourceNotFoundException("Unable to get message entries for language '" + language + "' in dictionary '" + dictionaryPath + "'", e);
+                }
+                messagePerLanguage.put(language, message);
+            }
+           return createResource(parent, resourceResolver, path, dictionaryService.isEditableDictionary(dictionaryResource), messagePerLanguage);
+        } else {
+            throw new ResourceNotFoundException(path, "Unable to get underlying dictionary resource for path '" + dictionaryPath + "'");
         }
-        return null;
     }
 
-    private boolean isMessageEntry(Resource dictionaryResource, String key) {
-        List<String> languages = dictionaryService.getLanguages(dictionaryResource);
-        // in order to speed things up always start with language "en" (if existing)
-        String mostCompleteLanguage = Locale.ENGLISH.getLanguage();
-        if (languages.contains(mostCompleteLanguage)) {
-            languages.remove(mostCompleteLanguage);
-            languages.add(0, mostCompleteLanguage);
-        }
+    static @NotNull Resource createResource(@Nullable Resource parent, @NotNull ResourceResolver resourceResolver, 
+            @NotNull String path, boolean isEditable, @NotNull Map<String, Message> messagePerLanguage) {
+        return new ValueMapResource(resourceResolver, path, RESOURCE_TYPE, new ValueMapDecorator(createResourceProperties(path, isEditable, messagePerLanguage)));
+    }
 
-        if (!languages.isEmpty()) {
-            for (String language : languages) {
-                Resource languageResource = dictionaryService.getLanguageResource(dictionaryResource, language);
-                if (languageResource != null) {
-                    Resource messageEntryResource = dictionaryService.getMessageEntryResource(languageResource, key);
-                    if (messageEntryResource != null) {
-                        return true;
-                    }
-                }
+    private static String extractKeyFromPath(@NotNull String path) {
+        return Text.unescapeIllegalJcrChars(Text.getName(path));
+    }
+
+    public static @NotNull Map<String, Object> createResourceProperties(@NotNull String path, boolean isEditable, @NotNull Map<String, Message> messagePerLanguage) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(KEY, extractKeyFromPath(path));
+        properties.put("path", path);
+        properties.put("editable", isEditable);
+        properties.put(DICTIONARY_PATH, getDictionaryPath(path));
+        properties.put(LANGUAGES, messagePerLanguage.keySet());
+        List<String> messageEntryPaths = new ArrayList<>();
+        for (Entry<String, Message> messageEntryPerLanguageEntry : messagePerLanguage.entrySet()) {
+            Message message = messageEntryPerLanguageEntry.getValue();
+            final String text;
+            if (message == null) {
+                text = "";
+            } else {
+                text = message.getText();
+                message.getResourcePath().ifPresent(messageEntryPaths::add);
             }
+            properties.put(messageEntryPerLanguageEntry.getKey(), text);
         }
-        return false;
+        // all paths to replicate
+        properties.put(MESSAGE_ENTRY_PATHS, messageEntryPaths);
+        return properties;
+    }
+
+    public static @NotNull String getDictionaryPath(@NotNull String path) {
+        return Text.getRelativeParent(path, 1).replaceFirst(ROOT, "");
     }
 
     @Override

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/package-info.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/package-info.java
@@ -1,4 +1,4 @@
-@Version("1.0.0")
+@Version("2.0.0")
 package be.orbinson.aem.dictionarytranslator.services;
 
 import org.osgi.annotation.versioning.Version;

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateMessageEntryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateMessageEntryServlet.java
@@ -1,5 +1,6 @@
 package be.orbinson.aem.dictionarytranslator.servlets.action;
 
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
 import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -57,19 +58,20 @@ public class CreateMessageEntryServlet extends SlingAllMethodsServlet {
                     LOG.debug("Create message entry on path '{}/{}'", dictionary, key);
                     String message = request.getParameter(language);
                     if (!dictionaryService.keyExists(dictionaryResource, language, key)) {
-                        dictionaryService.createMessageEntry(resourceResolver, dictionaryResource, language, key, message);
+                        dictionaryService.createOrUpdateMessageEntry(dictionaryResource, language, key, message);
                     } else {
                         HtmlResponse htmlResponse = new HtmlResponse();
                         htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Can not create message entry %s, key already exists", key));
                         htmlResponse.send(response, true);
                     }
                 }
+                resourceResolver.commit();
             } else {
                 HtmlResponse htmlResponse = new HtmlResponse();
                 htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to get dictionary '%s'", dictionary));
                 htmlResponse.send(response, true);
             }
-        } catch (PersistenceException e) {
+        } catch (PersistenceException|DictionaryException e) {
             HtmlResponse htmlResponse = new HtmlResponse();
             htmlResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, String.format("Unable to create key '%s' on dictionary '%s': %s", key, dictionary, e.getMessage()));
             htmlResponse.send(response, true);

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteDictionaryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteDictionaryServlet.java
@@ -1,9 +1,13 @@
 package be.orbinson.aem.dictionarytranslator.servlets.action;
 
-import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
-import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
+import java.io.IOException;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
@@ -12,9 +16,10 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import javax.servlet.Servlet;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import com.day.cq.replication.ReplicationException;
+
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 
 @Component(service = Servlet.class)
 @SlingServletResourceTypes(
@@ -42,7 +47,7 @@ public class DeleteDictionaryServlet extends SlingAllMethodsServlet {
             for (String dictionaryPath : dictionaries) {
                 try {
                     dictionaryService.deleteDictionary(resourceResolver, dictionaryPath);
-                } catch (DictionaryException e) {
+                } catch (DictionaryException | ReplicationException | PersistenceException e) {
                     HtmlResponse htmlResponse = new HtmlResponse();
                     htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to delete dictionary '%s': %s", dictionaryPath, e.getMessage()));
                     htmlResponse.send(response, true);

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServlet.java
@@ -1,10 +1,14 @@
 package be.orbinson.aem.dictionarytranslator.servlets.action;
 
-import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
-import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
+import java.io.IOException;
+
+import javax.servlet.Servlet;
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
@@ -14,9 +18,10 @@ import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import javax.servlet.Servlet;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+import com.day.cq.replication.ReplicationException;
+
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 
 @Component(service = Servlet.class)
 @SlingServletResourceTypes(
@@ -43,13 +48,13 @@ public class DeleteLanguageServlet extends SlingAllMethodsServlet {
             Resource dictionaryResource = resourceResolver.getResource(dictionary);
             try {
                 if (dictionaryResource != null) {
-                    dictionaryService.deleteLanguage(resourceResolver, dictionaryResource, language);
+                    dictionaryService.deleteLanguage(dictionaryResource, language);
                 } else {
                     HtmlResponse htmlResponse = new HtmlResponse();
                     htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to get dictionary '%s'", dictionary));
                     htmlResponse.send(response, true);
                 }
-            } catch (DictionaryException e) {
+            } catch (DictionaryException | PersistenceException | ReplicationException e) {
                 HtmlResponse htmlResponse = new HtmlResponse();
                 htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to delete language '%s': %s", language, e.getMessage()));
                 htmlResponse.send(response, true);

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateMessageEntryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/UpdateMessageEntryServlet.java
@@ -46,8 +46,8 @@ public class UpdateMessageEntryServlet extends SlingAllMethodsServlet {
             htmlResponse.send(response, true);
         } else {
             ResourceResolver resourceResolver = request.getResourceResolver();
-            Resource combiningMessageEntryResource = resourceResolver.getResource(combiningMessageEntryPath);
             try {
+                Resource combiningMessageEntryResource = resourceResolver.getResource(combiningMessageEntryPath);
                 if (combiningMessageEntryResource != null) {
                     // javasecurity:S5145
                     LOG.debug("Update message entry for path '{}'", combiningMessageEntryPath);
@@ -77,8 +77,9 @@ public class UpdateMessageEntryServlet extends SlingAllMethodsServlet {
                 if (message == null) {
                     throw new DictionaryException("Unable to get message for language '" + language + "'");
                 }
-                dictionaryService.updateMessageEntry(resourceResolver, dictionaryResource, language, key, message);
+                dictionaryService.createOrUpdateMessageEntry(dictionaryResource, language, key, message);
             }
+            resourceResolver.commit();
         } else {
             throw new DictionaryException("Could not find dictionary path");
         }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntryDatasource.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntryDatasource.java
@@ -33,6 +33,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+/**
+ * This data source has two different use cases:
+ * <ol>
+ * <li>It is used backing a coral table to display dictionary entries for all languages below a given dictionary</li>
+ * <li>It is used to populate the edit dialog for a single message entry (/apps/aem-dictionary-translator/content/granite/dialog/dictionary/key/update/.content.xml)</li>
+ * 
+ */
 @Component(service = Servlet.class)
 @SlingServletResourceTypes(
         resourceTypes = "aem-dictionary-translator/datasource/combining-message-entry",
@@ -59,7 +66,7 @@ public class CombiningMessageEntryDatasource extends SlingSafeMethodsServlet {
     }
 
     @NotNull
-    private static ValueMapResource getColumn(ResourceResolver resourceResolver, String key, Object value) {
+    static ValueMapResource getColumn(ResourceResolver resourceResolver, String key, Object value) {
         ValueMap valueMap = new ValueMapDecorator(Map.of(
                 key, value,
                 "sortable", true
@@ -74,6 +81,8 @@ public class CombiningMessageEntryDatasource extends SlingSafeMethodsServlet {
             Resource keyResource = resourceResolver.getResource(path);
             if (keyResource != null) {
                 resourceList.add(keyResource);
+            } else {
+                throw new IllegalStateException("Could not get resource for path: " + path + ". Probably the mandatory CombiningMessageEntryResourceProvider is not active.");
             }
         }
     }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/utils/DictionaryConstants.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/utils/DictionaryConstants.java
@@ -10,5 +10,6 @@ public final class DictionaryConstants {
     public static final String SLING_MESSAGE = "sling:message";
     public static final String SLING_MESSAGEENTRY = "sling:MessageEntry";
     public static final String SLING_MESSAGE_MIXIN = "sling:Message";
+    public static final String MIX_LANGUAGE = "mix:language";
 
 }

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImplTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/models/impl/DictionaryImplTest.java
@@ -1,5 +1,6 @@
 package be.orbinson.aem.dictionarytranslator.models.impl;
 
+import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
 import be.orbinson.aem.dictionarytranslator.models.Dictionary;
 import be.orbinson.aem.dictionarytranslator.services.impl.DictionaryServiceImpl;
 import com.day.cq.replication.Replicator;
@@ -49,7 +50,7 @@ class DictionaryImplTest {
     }
 
     @Test
-    void dictionaryShouldReturnCorrectKeyCount() {
+    void dictionaryShouldReturnCorrectKeyCount() throws DictionaryException {
         context.currentResource("/content/dictionaries/fruit/i18n");
 
         Dictionary dictionary = context.request().adaptTo(Dictionary.class);
@@ -75,7 +76,7 @@ class DictionaryImplTest {
     }
 
     @Test
-    void dictionaryShouldReturnCorrectKeys() {
+    void dictionaryShouldReturnCorrectKeys() throws DictionaryException {
         context.currentResource("/content/dictionaries/fruit/i18n");
 
         Dictionary dictionary = context.request().adaptTo(Dictionary.class);

--- a/core/src/test/resources/fruit.de.json
+++ b/core/src/test/resources/fruit.de.json
@@ -1,0 +1,5 @@
+{
+"apple": "Apfel",
+"banana": "Banane",
+"cherry": "Kirsche"
+}

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                             <goals>
                                 <goal>baseline</goal>
                             </goals>
+                            <configuration>
+                                <diffignores>
+                                    <!-- ignore Bundle-Version header for baseline, i.e. no enforcement of specific bundle versions -->
+                                    <diffignore>Bundle-Version</diffignore>
+                                </diffignores>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>

--- a/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/components/dictionary/dictionary.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/components/dictionary/dictionary.html
@@ -10,7 +10,7 @@
     <td is="coral-table-cell">${resource.path}</td>
     <td is="coral-table-cell">${model.languageList}</td>
     <td is="coral-table-cell">${model.basename}</td>
-    <td is="coral-table-cell">${model.type}</td>
+    <td is="coral-table-cell">${model.type.toString}</td><!--/* call toString due to https://issues.apache.org/jira/browse/SLING-12785 */-->
     <td is="coral-table-cell">
         <coral-icon
                 class="icon--${model.editable ? 'success' : 'warning'}"

--- a/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/components/dictionary/dictionary.html
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/components/dictionary/dictionary.html
@@ -10,6 +10,7 @@
     <td is="coral-table-cell">${resource.path}</td>
     <td is="coral-table-cell">${model.languageList}</td>
     <td is="coral-table-cell">${model.basename}</td>
+    <td is="coral-table-cell">${model.type}</td>
     <td is="coral-table-cell">
         <coral-icon
                 class="icon--${model.editable ? 'success' : 'warning'}"

--- a/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/content/dictionaries/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aem-dictionary-translator/content/dictionaries/.content.xml
@@ -192,6 +192,10 @@
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Basename"
                             sortable="true"/>
+                    <type
+                            jcr:primaryType="nt:unstructured"
+                            jcr:title="Type"
+                            sortable="true"/>
                     <editable
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Editable"


### PR DESCRIPTION
This closes #26

Also it streamlines a bit the exception handling and improves the Dictionary Service API (removal of redundant arguments, consistent use of exceptions).
In addition it adds caching on DictionaryService level.


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [x] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
