### PR TITLE
Fix sorting order of values in "languages" property of

### DIFF
--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/DictionaryService.java
@@ -31,6 +31,11 @@ public interface DictionaryService {
 
     void deleteDictionary(ResourceResolver resourceResolver, String dictionaryPath) throws DictionaryException, ReplicationException, PersistenceException;
 
+    /**
+     * Returns the list of languages for the given dictionary resource in alphabetical order.
+     * @param dictionaryResource
+     * @return the list of languages for the given dictionary resource in alphabetical order
+     */
     List<String> getLanguages(Resource dictionaryResource);
 
     void deleteLanguage(Resource dictionaryResource, String language) throws DictionaryException, ReplicationException, PersistenceException;

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProvider.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -69,7 +70,7 @@ public class CombiningMessageEntryResourceProvider extends ResourceProvider<Obje
         Resource dictionaryResource = resourceResolver.getResource(dictionaryPath);
 
         if (dictionaryResource != null) {
-            @NotNull Map<String, Message> messagePerLanguage = new HashMap<>();
+            @NotNull Map<String, Message> messagePerLanguage = new LinkedHashMap<>(); // preserve the order of languages
             List<String> languages = dictionaryService.getLanguages(dictionaryResource);
             for (String language : languages) {
                 Message message;

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProviderTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProviderTest.java
@@ -1,16 +1,25 @@
 package be.orbinson.aem.dictionarytranslator.services.impl;
 
-import com.day.cq.replication.Replicator;
-import io.wcm.testing.mock.aem.junit5.AemContext;
-import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.mock;
+import com.day.cq.replication.Replicator;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 
 @ExtendWith(AemContextExtension.class)
 class CombiningMessageEntryResourceProviderTest {
@@ -35,12 +44,37 @@ class CombiningMessageEntryResourceProviderTest {
     }
 
     @Test
-    void syntheticPathShouldReturnNonNullResource() {
-        assertNotNull(context.resourceResolver().getResource("/mnt/dictionary/content/dictionaries/fruit/i18n/apple"));
+    void syntheticMessageEntryPathShouldReturnNonNullResource() {
+        Resource resource = context.resourceResolver().getResource("/mnt/dictionary/content/dictionaries/fruit/i18n/apple");
+        assertNotNull(resource);
+        ValueMap properties = resource.getValueMap();
+        Map<String, Object> expectedProperties = Map.of(
+                "path", "/mnt/dictionary/content/dictionaries/fruit/i18n/apple",
+                "languages", new String[]{"en", "nl_BE"}, // languages must always be in alphabetical order
+                "nl_BE", "Appel",
+                "en", "Apple",
+                "editable", Boolean.FALSE, // because resource resolver is not adaptable to Session
+                "key", "apple",
+                "dictionaryPath", "/content/dictionaries/fruit/i18n",
+                "messageEntryPaths", new String[]{
+                        "/content/dictionaries/fruit/i18n/en/apple", "/content/dictionaries/fruit/i18n/nl_be/apple"
+                }
+        );
+        expectedProperties.forEach((key, value) -> {
+            Object actualValue = properties.get(key);
+            assertNotNull(actualValue, "Property " + key + " should not be null");
+            if (actualValue instanceof Collection) {
+                assertArrayEquals((Object[])value, ((Collection<?>)actualValue).toArray());
+            } else {
+                assertEquals(value, actualValue);
+            }
+        });
+        assertEquals(expectedProperties.size(), properties.size());
     }
 
     @Test
     void listChildrenShouldNotFailOnResource() {
         assertDoesNotThrow(() -> context.resourceResolver().getResource("/mnt/dictionary/content/dictionaries/fruit/i18n/apple").listChildren());
     }
+    
 }


### PR DESCRIPTION
CombiningMessageEntryResource

This restores using the alphabetical order in the message entry table rows. This regressed with
https://github.com/orbinson/aem-dictionary-translator/commit/e78538d48e748dc0aba8b363a49a1a5340e60891


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [ ] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
