### PR TITLE
Use Java unicode escape sequence for "/" and "%" to represent the key

### DIFF
--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntriesDatasourceForTable.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntriesDatasourceForTable.java
@@ -88,7 +88,7 @@ public class CombiningMessageEntriesDatasourceForTable extends SlingSafeMethodsS
     private static void setDataSource(ResourceResolver resourceResolver, List<Resource> resourceList, Dictionary dictionary) throws DictionaryException {
         for (String key : dictionary.getKeys()) {
             // the escaping of the key is necessary as it may contain "/" which has a special meaning (even outside the JCR provider)
-            String path = CombiningMessageEntryResourceProvider.ROOT + dictionary.getResource().getPath() + '/' + Text.escapeIllegalJcrChars(key);
+            String path = CombiningMessageEntryResourceProvider.createPath(dictionary.getResource().getPath(), key);
             Resource keyResource = resourceResolver.getResource(path);
             if (keyResource != null) {
                 resourceList.add(keyResource);

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProviderTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/services/impl/CombiningMessageEntryResourceProviderTest.java
@@ -6,9 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -82,5 +85,15 @@ class CombiningMessageEntryResourceProviderTest {
     void listChildrenShouldNotFailOnResource() {
         assertDoesNotThrow(() -> context.resourceResolver().getResource("/mnt/dictionary/content/dictionaries/fruit/i18n/apple").listChildren());
     }
-    
+
+    @Test
+    void testPathEscaping() {
+        String key = "key/with%23special%20characters&=";
+        String escapedPath = CombiningMessageEntryResourceProvider.createPath("/my/path", key);
+        assertEquals(key, CombiningMessageEntryResourceProvider.extractKeyFromPath(escapedPath));
+        assertEquals(5, StringUtils.countMatches(escapedPath, '/')); // no additional slash in the key part of the path
+        assertEquals(0, StringUtils.countMatches(escapedPath, '%')); // no percent sign at all in the path
+        // make sure the heuristic in /libs/clientlibs/granite/uritemplate/URITemplate.js in its "isEncoded(String)" method returns false
+        assertEquals(escapedPath, URLDecoder.decode(escapedPath, StandardCharsets.UTF_8));
+    }
 }

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntriesDatasourceForTableTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/datasource/CombiningMessageEntriesDatasourceForTableTest.java
@@ -110,7 +110,7 @@ class CombiningMessageEntriesDatasourceForTableTest {
                 new SyntheticResource(context.resourceResolver(), "/mnt/dictionary/content/dictionaries/fruit/i18n/apple", CombiningMessageEntryResourceProvider.RESOURCE_TYPE),
                 new SyntheticResource(context.resourceResolver(), "/mnt/dictionary/content/dictionaries/fruit/i18n/banana", CombiningMessageEntryResourceProvider.RESOURCE_TYPE),
                 new SyntheticResource(context.resourceResolver(), "/mnt/dictionary/content/dictionaries/fruit/i18n/cherry", CombiningMessageEntryResourceProvider.RESOURCE_TYPE),
-                new SyntheticResource(context.resourceResolver(), "/mnt/dictionary/content/dictionaries/fruit/i18n/" + Text.escapeIllegalJcrChars(KEY_SPECIAL_CHARACTERS), CombiningMessageEntryResourceProvider.RESOURCE_TYPE)
+                new SyntheticResource(context.resourceResolver(), CombiningMessageEntryResourceProvider.createPath("/content/dictionaries/fruit/i18n", KEY_SPECIAL_CHARACTERS), CombiningMessageEntryResourceProvider.RESOURCE_TYPE)
         );
     }
 


### PR DESCRIPTION
name

This prevents the heuristic in
libs/clientlibs/granite/uritemplate/URITemplate.js#isEncoded(String) to not apply additional URL encoding if used as request parameter

This closes #180


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [ ] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)