### PR TITLE
Always log servlet errors on server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editing a key containing newlines (\n) produces duplicate entries [#208](https://github.com/orbinson/aem-dictionary-translator/issues/208)
 - Importing a key that has the same name as a sling:MessageEntry node generates an error [#209](https://github.com/orbinson/aem-dictionary-translator/issues/209)
 
-
 ### Changed
 
 - Allow empty value on i18n key [#172](https://github.com/orbinson/aem-dictionary-translator/issues/172)
+- Improve exception handling in servlets [#212](https://github.com/orbinson/aem-dictionary-translator/issues/212)
 
 ## [1.4.1] - 2025-06-04
 

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServlet.java
@@ -1,24 +1,19 @@
 package be.orbinson.aem.dictionarytranslator.servlets.action;
 
-import java.io.IOException;
 import java.util.Locale;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.apache.sling.servlets.post.HtmlResponse;
-import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.day.cq.replication.ReplicationException;
 import com.day.cq.replication.Replicator;
 
 import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
@@ -32,8 +27,14 @@ import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 )
 public class DeleteLanguageServlet extends AbstractDictionaryServlet {
 
+    public DeleteLanguageServlet() {
+        super("Unable to delete language");
+    }
+
     public static final String LANGUAGE_PARAM = "language";
     public static final String DICTIONARY_PARAM = "dictionary";
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteLanguageServlet.class);
 
     @Reference
     private transient DictionaryService dictionaryService;
@@ -42,20 +43,20 @@ public class DeleteLanguageServlet extends AbstractDictionaryServlet {
     private Replicator replicator;
 
     @Override
-    @SuppressWarnings("java:S1075")
-    public void doPost(SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws IOException {
+    protected void internalDoPost(SlingHttpServletRequest request, HtmlResponse htmlResponse) throws Throwable {
         final String language = getMandatoryParameter(request, LANGUAGE_PARAM, false);
         final String dictionary = getMandatoryParameter(request, DICTIONARY_PARAM, false);
 
+        htmlResponse.setPath(dictionary + "/" + language);
         ResourceResolver resourceResolver = request.getResourceResolver();
+        LOG.debug("Deleting language dictionary '{}' below '{}'", language, dictionary);
         try {
             dictionaryService.deleteDictionary(replicator, resourceResolver, dictionary, Locale.forLanguageTag(language));
-            resourceResolver.commit();
-        } catch (DictionaryException | PersistenceException | ReplicationException e) {
-            HtmlResponse htmlResponse = new HtmlResponse();
-            htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to delete language '%s': %s", language, e.getMessage()));
-            htmlResponse.send(response, true);
-        } 
+        } catch (DictionaryException e) {
+            htmlResponse.setStatus(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
+            return;
+        }
+        resourceResolver.commit();
     }
 
 }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteMessageEntryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteMessageEntryServlet.java
@@ -1,31 +1,25 @@
 package be.orbinson.aem.dictionarytranslator.servlets.action;
 
-import java.io.IOException;
 import java.util.Collection;
 
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
-import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.apache.sling.servlets.post.HtmlResponse;
-import org.jetbrains.annotations.NotNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.day.cq.replication.ReplicationException;
 import com.day.cq.replication.Replicator;
 
-import be.orbinson.aem.dictionarytranslator.exception.DictionaryException;
-import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 import be.orbinson.aem.dictionarytranslator.services.Dictionary;
+import be.orbinson.aem.dictionarytranslator.services.DictionaryService;
 import be.orbinson.aem.dictionarytranslator.services.impl.CombiningMessageEntryResourceProvider;
 
 @Component(service = Servlet.class)
@@ -35,6 +29,10 @@ import be.orbinson.aem.dictionarytranslator.services.impl.CombiningMessageEntryR
         methods = "POST"
 )
 public class DeleteMessageEntryServlet extends AbstractDictionaryServlet {
+    public DeleteMessageEntryServlet() {
+        super("Unable to delete message entry");
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(DeleteMessageEntryServlet.class);
     public static final String ITEM_PARAM = "item";
 
@@ -45,16 +43,14 @@ public class DeleteMessageEntryServlet extends AbstractDictionaryServlet {
     private Replicator replicator;
     
     @Override
-    protected void doPost(SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws IOException {
-
+    protected void internalDoPost(SlingHttpServletRequest request, HtmlResponse htmlResponse) throws Throwable {
         Collection<String> combiningMessageEntryPaths  = getMandatoryParameters(request, ITEM_PARAM, false);
         for (String combiningMessageEntryPath : combiningMessageEntryPaths) {
+            htmlResponse.setPath(combiningMessageEntryPath);
             ResourceResolver resourceResolver = request.getResourceResolver();
             Resource combiningMessageEntryResource = resourceResolver.getResource(combiningMessageEntryPath);
             if (combiningMessageEntryResource == null) {
-                HtmlResponse htmlResponse = new HtmlResponse();
                 htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Unable to get message entry '%s'", combiningMessageEntryPath));
-                htmlResponse.send(response, true);
                 return;
             }
             try {
@@ -69,6 +65,7 @@ public class DeleteMessageEntryServlet extends AbstractDictionaryServlet {
                 }
                 for (Dictionary dictionary : dictionaryService.getDictionaries(resourceResolver, dictionaryPath)) {
                     if (dictionary.getEntries().containsKey(key)) {
+                        LOG.debug("Deleting message entry for key '{}' in dictionary '{}'...", key, dictionary.getPath());
                         dictionary.deleteEntry(replicator, resourceResolver, key);
                     } else {
                         LOG.debug("No message entry found for key '{}' in dictionary '{}'", key, dictionary.getPath());
@@ -78,16 +75,8 @@ public class DeleteMessageEntryServlet extends AbstractDictionaryServlet {
                 // javasecurity:S5145
                 LOG.debug("Deleted message entry for key '{}' from all dictionaries below '{}'", key, dictionaryPath);
             
-            } catch (DictionaryException | PersistenceException | ReplicationException e) {
-                HtmlResponse htmlResponse = new HtmlResponse();
-                htmlResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, String.format("Unable to delete message entry '%s': %s", combiningMessageEntryPath, e.getMessage()));
-                htmlResponse.send(response, true);
-                return;
             } catch (IllegalArgumentException e) {
-                HtmlResponse htmlResponse = new HtmlResponse();
                 htmlResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST, String.format("Missing mandatory property from resource: %s", combiningMessageEntryPath, e.getMessage()));
-                htmlResponse.send(response, true);
-                return;
             } 
         }
     }

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ExportDictionaryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ExportDictionaryServlet.java
@@ -37,6 +37,10 @@ import be.orbinson.aem.dictionarytranslator.services.Dictionary;
         methods = "POST")
 public class ExportDictionaryServlet extends AbstractDictionaryServlet {
 
+    public ExportDictionaryServlet() {
+        super("Unable to export dictionary");
+    }
+
     public static final String KEY_HEADER = "KEY";
     public static final String VALUE_EMPTY = "<empty>";
     private static final Logger LOG = LoggerFactory.getLogger(ExportDictionaryServlet.class);
@@ -49,10 +53,6 @@ public class ExportDictionaryServlet extends AbstractDictionaryServlet {
         String dictionaryPath = getMandatoryParameter(request, "dictionary", false);
         Optional<String> delimiter = getOptionalParameter(request, "delimiter", false);
 
-        response.setContentType("text/csv");
-        response.setCharacterEncoding("UTF-8");
-        response.setHeader("Content-Disposition", "attachment; filename=\"dictionary_" + dictionaryPath + ".csv");
-
         ResourceResolver resolver = request.getResourceResolver();
         try {
             Collection<Dictionary> dictionaries = dictionaryService.getDictionaries(resolver, dictionaryPath);
@@ -62,6 +62,9 @@ public class ExportDictionaryServlet extends AbstractDictionaryServlet {
                 htmlResponse.send(response, true);
                 return;
             }
+            response.setContentType("text/csv");
+            response.setCharacterEncoding("UTF-8");
+            response.setHeader("Content-Disposition", "attachment; filename=\"dictionary_" + dictionaryPath + ".csv");
             try (CSVPrinter printer = createCsvPrinter(response.getWriter(), delimiter, dictionaries.stream().map(Dictionary::getLanguage).collect(Collectors.toList()))) {
                 Collection<String> keys = dictionaries.stream().flatMap(d -> {
                     try {

--- a/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ImportDictionaryServlet.java
+++ b/core/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ImportDictionaryServlet.java
@@ -49,6 +49,10 @@ import be.orbinson.aem.dictionarytranslator.services.impl.DictionaryImpl;
 )
 public class ImportDictionaryServlet extends AbstractDictionaryServlet {
 
+    public ImportDictionaryServlet() {
+        super("Unable to import CSV file");
+    }
+
     @Reference
     private DictionaryService dictionaryService;
 
@@ -56,18 +60,12 @@ public class ImportDictionaryServlet extends AbstractDictionaryServlet {
     private Replicator replicator;
 
     @Override
-    public void doPost(SlingHttpServletRequest request, @NotNull SlingHttpServletResponse response) throws IOException {
+    protected void internalDoPost(SlingHttpServletRequest request, HtmlResponse htmlResponse) throws Throwable {
         String dictionaryPath = getMandatoryParameter(request, "dictionary", false);
         RequestParameter csvfile = request.getRequestParameter("csvfile");
 
         if (csvfile != null) {
-            try {
-                processCsvFile(request, dictionaryPath, csvfile.getInputStream());
-            } catch (IOException | RepositoryException | DictionaryException | ReplicationException e) {
-                HtmlResponse htmlResponse = new HtmlResponse();
-                htmlResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Error while importing CSV file: " + e.getMessage());
-                htmlResponse.send(response, true);
-            }
+            processCsvFile(request, dictionaryPath, csvfile.getInputStream());
         }
     }
 

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateDictionaryServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateDictionaryServletTest.java
@@ -94,7 +94,7 @@ class CreateDictionaryServletTest {
 
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
         for (String language : languages) {
             Resource resource = context.resourceResolver().getResource("/content/dictionaries/fruit/" + language);
             assertNotNull(resource);

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLanguageServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateLanguageServletTest.java
@@ -70,7 +70,7 @@ class CreateLanguageServletTest {
         context.request().setMethod("POST");
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/fruit/i18n/en");
         ValueMap properties = resource.getValueMap();
@@ -97,7 +97,7 @@ class CreateLanguageServletTest {
         ValueMap properties = resource.getValueMap();
 
         assertNotNull(resource);
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
         assertEquals("en", properties.get("jcr:language"));
         assertEquals("mix:language", properties.get("jcr:mixinTypes", String.class));
         assertEquals("namespace", properties.get("sling:basename", String.class));

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateMessageEntryServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/CreateMessageEntryServletTest.java
@@ -108,7 +108,7 @@ class CreateMessageEntryServletTest {
 
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/fruit/i18n/en/apple");
         assertNotNull(resource);
@@ -140,7 +140,7 @@ class CreateMessageEntryServletTest {
 
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/fr/greeting");
         assertNotNull(resource);
@@ -167,7 +167,7 @@ class CreateMessageEntryServletTest {
 
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/fr/greeting");
         assertNotNull(resource);
@@ -191,7 +191,7 @@ class CreateMessageEntryServletTest {
                 "fr", ""
         ));
         servlet.service(context.request(), context.response());
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         context.request().setParameterMap(Map.of(
                 "dictionary", "/content/dictionaries/i18n",
@@ -201,7 +201,7 @@ class CreateMessageEntryServletTest {
         ));
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         Resource resource = context.resourceResolver().getResource("/content/dictionaries/i18n/en/greeting");
         ValueMap properties = resource.getValueMap();
@@ -233,7 +233,7 @@ class CreateMessageEntryServletTest {
 
         servlet.service(context.request(), context.response());
 
-        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_CREATED, context.response().getStatus());
 
         // invalidate cache
         dictionaryService.onChange(List.of(new ResourceChange(ChangeType.ADDED, "/content/dictionaries/i18n/en", false)));

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteDictionaryServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteDictionaryServletTest.java
@@ -72,7 +72,7 @@ class DeleteDictionaryServletTest {
     }
 
     @Test
-    void deleteMultipleDictionaries() throws IOException {
+    void deleteMultipleDictionaries() throws IOException, ServletException {
         context.create().resource("/content/dictionaries/site-a/i18n");
         context.create().resource("/content/dictionaries/site-b/i18n");
         context.create().resource("/content/dictionaries/site-c/i18n");
@@ -89,7 +89,7 @@ class DeleteDictionaryServletTest {
     }
 
     @Test
-    void deleteNonExistingDictionary() throws IOException {
+    void deleteNonExistingDictionary() throws IOException, ServletException {
         context.create().resource("/content/dictionaries/site-a/i18n");
         context.request().setParameterMap(Map.of(
                 DeleteDictionaryServlet.DICTIONARIES_PARAM, new String[]{"/content/dictionaries/site-b/i18n"}
@@ -98,6 +98,6 @@ class DeleteDictionaryServletTest {
         servlet.doPost(context.request(), context.response());
 
         assertNotNull(context.resourceResolver().getResource("/content/dictionaries/site-a/i18n"));
-        assertEquals(HttpServletResponse.SC_BAD_REQUEST, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, context.response().getStatus());
     }
 }

--- a/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServletTest.java
+++ b/core/src/test/java/be/orbinson/aem/dictionarytranslator/servlets/action/DeleteLanguageServletTest.java
@@ -104,6 +104,6 @@ class DeleteLanguageServletTest {
         servlet.service(context.request(), context.response());
 
         assertNotNull(context.resourceResolver().getResource("/content/dictionaries/i18n/en"));
-        assertEquals(HttpServletResponse.SC_BAD_REQUEST, context.response().getStatus());
+        assertEquals(HttpServletResponse.SC_NOT_FOUND, context.response().getStatus());
     }
 }


### PR DESCRIPTION
Also use HTMLResponse for all servlets which don't expose any other content than the status.
Change some status codes to be more in line with ReST principles.

This closes #212


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [x] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
