### PR TITLE
Use Njord to publish via Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       push: ${{ inputs.push }}
       java-version: 11
     secrets:
-      username: ${{ secrets.SONATYPE_USERNAME }}
-      password: ${{ secrets.SONATYPE_PASSWORD }}
+      username: ${{ secrets.SONATYPE_CENTRAL_PORTAL_TOKEN_USER }}
+      password: ${{ secrets.SONATYPE_CENTRAL_PORTAL_TOKEN_PASSWORD }}
       gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: orbinson/workflows/.github/workflows/maven-release.yml@main
+    uses: orbinson/workflows/.github/workflows/maven-release.yml@njord
     with:
       central: ${{ inputs.central }}
       github: ${{ inputs.github }}

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <name>Central Repository OSSRH - Snapshots</name>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>sonatype-central-portal</id>
+            <name>Central Portal SNAPSHOT</name>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <name>Central Repository OSSRH</name>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>sonatype-central-portal</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </distributionManagement>
 
@@ -77,6 +77,7 @@
         <vault.password>admin</vault.password>
 
         <bnd.version>6.4.0</bnd.version>
+        <njord.version>0.8.2</njord.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <componentName>Dictionary Translator</componentName>
@@ -87,6 +88,13 @@
     </properties>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>eu.maveniverse.maven.njord</groupId>
+                <artifactId>extension3</artifactId>
+                <version>${njord.version}</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -146,6 +154,11 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>eu.maveniverse.maven.plugins</groupId>
+                    <artifactId>njord</artifactId>
+                    <version>${njord.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
@@ -413,19 +426,6 @@ Bundle-DocURL:
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.13</version>
                 </plugin>
-                <!-- Sonatype Release -->
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
This closes #206


**Checklist before requesting a review**

- [ ] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I have performed a self-review of my code
- [ ] Tests are added where appropriate
- [ ] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)

This requires
1. Adaptations to https://github.com/orbinson/workflows/blob/main/.github/workflows/maven-release.yml to write the following into the `settings.xml`:
   ```
       <server>
            <id>sonatype-central-portal</id>
            <username>...</username>
            <password>...</password>
            <configuration>
                <njord.publisher>sonatype-cp</njord.publisher>
                <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
            </configuration>
        </server>
   ```

  Optionally both configurations can also be given as CLI parameters:
  - https://maveniverse.eu/docs/njord/plugin-documentation/publish-mojo.html#publisher
  - https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#altDeploymentRepository (compare with https://github.com/maveniverse/njord/issues/162)
  
2. The org/repo secrets:
   - `SONATYPE_CENTRAL_PORTAL_TOKEN_USER`
   - `SONATYPE_CENTRAL_PORTAL_TOKEN_PASSWORD`

3. Add CLI arguments to automatically publish the staged repos via `njord.autoPublish`