### PR TITLE
Use "path" instead of "rootPath" in ActivationParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed 
+
+- NPE in Cloud Replication [#237](https://github.com/orbinson/aem-dictionary-translator/issues/237)
+
 ## [1.6.0] - 2025-07-26
 
 ### Fixed

--- a/core.cloud/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ReplicateDictionariesWithTreeActivationServlet.java
+++ b/core.cloud/src/main/java/be/orbinson/aem/dictionarytranslator/servlets/action/ReplicateDictionariesWithTreeActivationServlet.java
@@ -92,7 +92,8 @@ public class ReplicateDictionariesWithTreeActivationServlet extends AbstractDict
             LOG.debug("Using agent ID: {}", agentId);
             try {
                 ActivationParameters activationParameters = ActivationParameters.builder()
-                        .rootPath(path)
+                        .path(path)
+                        //.rootPath(...)  is not evaluated in the TreeActivationJob
                         .agentId(agentId)
                         // for now just hardcode the filter name, as only the SlingMessageNodeFilter is available
                         .filters(List.of(SlingMessageNodeFilter.NAME))
@@ -103,7 +104,7 @@ public class ReplicateDictionariesWithTreeActivationServlet extends AbstractDict
                         .userId(resourceResolver.getUserID())
                         .build();
                 String activationId = treeActivationService.start(activationParameters);
-                messages.add("Replication started for dictionary " + path + " with activation ID: " + activationId);
+                messages.add("Replication started for dictionary at " + path + " with activation ID: " + activationId);
             } catch (TreeActivationException e) {
                 LOG.error("Error while replicating dictionary at {}", path, e);
                 messages.add("Error while replicating dictionary at " + path + ": " + e.getMessage());


### PR DESCRIPTION
There are two mandatory parameters which throw NPEs if not set:
- path
- userId

The rootPath parameter is never evaluated.
This closes #237


**Checklist before requesting a review**

- [x] Contribution guidelines read in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] Tests are added where appropriate
- [x] The resolution of the issue is mentioned in the [CHANGELOG.md](CHANGELOG.md)
