### PR TITLE
Prevent Dependabot from upgrading JUnit 5 to 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "org.apache.commons:commons-csv"
         versions: [ "[1.10.0,)" ]
+      - dependency-name: "org.junit.jupiter:*"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.junit:junit-bom"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.junit.platform:*"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "npm"
     directory: "/ui.tests"
     reviewers:


### PR DESCRIPTION
Add ignore rules for major version updates to JUnit dependencies:
- org.junit.jupiter:*
- org.junit:junit-bom
- org.junit.platform:*

This prevents automatic PRs to upgrade from JUnit 5 to JUnit 6.