### PR TITLE
Update Node.js to latest LTS version 24.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,8 +470,8 @@ Bundle-DocURL:
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>1.15.1</version>
                     <configuration>
-                        <nodeVersion>v22.11.0</nodeVersion>
-                        <npmVersion>10.9.0</npmVersion>
+                        <nodeVersion>v24.12.0</nodeVersion>
+                        <npmVersion>11.6.2</npmVersion>
                         <installDirectory>${project.build.directory}</installDirectory>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Upgrade from Node.js v22.11.0 to v24.12.0 (Krypton LTS)
and npm from 10.9.0 to 11.6.2 in the frontend-maven-plugin
configuration.